### PR TITLE
Issue/#29 implement printf

### DIFF
--- a/src/kmain.c
+++ b/src/kmain.c
@@ -10,8 +10,8 @@
 #include <stdint.h>
 
 #include "libc/include/string.h"
-#include "libk/include/vga.h"
 
+#include "libk/include/kstd.h"
 #include "libk/include/kmem.h"
 #include "libk/include/vga.h"
 
@@ -23,6 +23,11 @@ void kmain(void) {
   vga_reset();
 
   vga_setattr(vga_attr(VGA_WHITE, VGA_BLACK));
-  vga_print("Hello, world!");
+
+  kprintf("Hello, %s!\n", "world");
+  vga_setattr(vga_attr(VGA_LIGHT_MAGENTA, VGA_BROWN));
+  
+  kprintf("What is this for %d (%x) improvement!", 1, 1);
+  
   vga_refresh();
 }

--- a/src/libk/include/vga.h
+++ b/src/libk/include/vga.h
@@ -137,7 +137,7 @@ extern uint16_t *vga_rotup(size_t nrows);
  * the current cursor location. All chars will be configured with the
  * default attributes.
  */
-extern uint16_t *vga_print(const char *str);
+extern uint16_t *vga_printstr(const char *str);
 
 /*
  * vga_newline
@@ -169,21 +169,21 @@ extern size_t vga_getcol(void);
  * vga_printhex
  * Prints @src in hex representation at the current cursor position.
  */
-extern uint16_t *vga_printhex(uint64_t src);
+extern uint16_t *vga_printhex(uint32_t src);
 
 /*
  * vga_printuint
  * Prints @src in unsigned decimal representation at the current
  * cursor position.
  */
-extern uint16_t *vga_printuint(uint64_t src);
+extern uint16_t *vga_printuint(uint32_t src);
 
 /*
  * vga_printint
  * Prints @src in decimal representation at the current cursor
  * position.
  */
-extern uint16_t *vga_printint(int64_t src);
+extern uint16_t *vga_printint(int32_t src);
 
 /*
  * vga_printptr

--- a/src/libk/include/vga.h
+++ b/src/libk/include/vga.h
@@ -132,7 +132,7 @@ extern uint16_t *vga_refresh(void);
 extern uint16_t *vga_rotup(size_t nrows);
 
 /*
- * vga_print
+ * vga_printstr
  * Prints the \0 terminated string @str to the screen, beginning at
  * the current cursor location. All chars will be configured with the
  * default attributes.

--- a/src/libk/kstd.c
+++ b/src/libk/kstd.c
@@ -7,6 +7,9 @@
  *
  * %x    hexadecimal
  * %u    unsigned decimal
+ * %d    decimal
+ * %s    string
+ * %c    single char
  *
  * %     percent sign
  */
@@ -20,18 +23,35 @@ void kprintf(char *format, ...) {
     if (*formatptr == '%') {
       formatptr++;
 
-      uint64_t uint_repl;
+      uint32_t uint_repl;
+      int32_t int_repl;
+      char *str_repl;
       
       switch (*formatptr) {
 
       case 'x':
-	uint_repl = va_arg(args, uint64_t);
+	uint_repl = va_arg(args, uint32_t);
 	vga_printhex(uint_repl);
 	break;
 
       case 'u':
-	uint_repl = va_arg(args, uint64_t);
+	uint_repl = va_arg(args, uint32_t);
 	vga_printuint(uint_repl);
+	break;
+
+      case 'd':
+	int_repl = va_arg(args, int32_t);
+	vga_printint(int_repl);
+	break;
+
+      case 's':
+	str_repl = va_arg(args, char*);
+	vga_printstr(str_repl);
+	break;
+
+      case 'c':
+	int_repl = va_arg(args, int32_t);
+	vga_putch(int_repl);
 	break;
 
       default:

--- a/src/libk/kstd.c
+++ b/src/libk/kstd.c
@@ -28,7 +28,6 @@ void kprintf(char *format, ...) {
       char *str_repl;
       
       switch (*formatptr) {
-
       case 'x':
 	uint_repl = va_arg(args, uint32_t);
 	vga_printhex(uint_repl);
@@ -58,7 +57,7 @@ void kprintf(char *format, ...) {
 	vga_putch('%');
 	break;
       }
-      
+
     } else {
       vga_putch(*formatptr);
     }

--- a/src/libk/vga.c
+++ b/src/libk/vga.c
@@ -63,14 +63,28 @@ uint16_t *vga_tell(void) {
  */
 uint16_t *vga_putch(const char ch) {
   uint16_t *cursor = vga_tell();
-  *cursor = vga_ch(ch, _defaultattr);
 
-  if (++_cursorx >= _config.sizex) {
-    ++_cursory;
-    _cursorx = 0;
+  switch (ch) {
+  case '\n':
+    vga_newline();
+    break;
 
-    if (_cursory >= _config.sizey)
-      vga_rotup(1);
+  case '\t':
+    vga_tab();
+    break;
+
+  default:
+    *cursor = vga_ch(ch, _defaultattr);
+
+    if (++_cursorx >= _config.sizex) {
+      ++_cursory;
+      _cursorx = 0;
+
+      if (_cursory >= _config.sizey)
+	vga_rotup(1);
+    }
+
+    break;
   }
   
   return vga_tell();
@@ -252,6 +266,6 @@ uint16_t *vga_printint(int32_t src) {
  * Prints the address @src is pointing to.
  */
 uint16_t *vga_printptr(void *ptr) {
-  uint64_t ptraddr = (uint64_t)ptr;
+  uint32_t ptraddr = (uint32_t)ptr;
   return vga_printhex(ptraddr);
 }

--- a/src/libk/vga.c
+++ b/src/libk/vga.c
@@ -126,7 +126,7 @@ uint16_t *vga_rotup(size_t nrows) {
  * the current cursor location. All chars will be configured with the
  * default attributes.
  */
-uint16_t *vga_print(const char *str) {
+uint16_t *vga_printstr(const char *str) {
   while (*str)
     vga_putch(*str++);
 
@@ -186,7 +186,7 @@ size_t vga_getcol(void) {
  * vga_printhex
  * Prints @src in hex representation at the current cursor position.
  */
-uint16_t *vga_printhex(uint64_t src) {
+uint16_t *vga_printhex(uint32_t src) {
   char glyphbuff[64] = { 0 };
   char glyphs[] = "0123456789abcdef";
 
@@ -202,7 +202,7 @@ uint16_t *vga_printhex(uint64_t src) {
   *glyphptr-- = 'x'; 
   *glyphptr = '0';
   
-  vga_print(glyphptr);
+  vga_printstr(glyphptr);
 
   return vga_tell();
 }
@@ -212,7 +212,7 @@ uint16_t *vga_printhex(uint64_t src) {
  * Prints @src in unsigned decimal representation at the current
  * cursor position.
  */
-uint16_t *vga_printuint(uint64_t src) {
+uint16_t *vga_printuint(uint32_t src) {
   char glyphbuff[64] = { 0 };
   char glyphs[] = "0123456789";
 
@@ -226,7 +226,7 @@ uint16_t *vga_printuint(uint64_t src) {
     *glyphptr = nextglyph;
   }
 
-  vga_print(glyphptr);
+  vga_printstr(glyphptr);
 
   return vga_tell();    
 }
@@ -236,7 +236,7 @@ uint16_t *vga_printuint(uint64_t src) {
  * Prints @src in decimal representation at the current cursor
  * position.
  */
-uint16_t *vga_printint(int64_t src) {
+uint16_t *vga_printint(int32_t src) {
   if (src < 0) {
     src *= -1;
     vga_putch('-');

--- a/src/makefile
+++ b/src/makefile
@@ -37,7 +37,8 @@ LIBC_OBJ = \
 
 LIBK_OBJ = \
 	$(LIBK_OBJ_DIR)/vga.o\
-	$(LIBK_OBJ_DIR)/kmem.o
+	$(LIBK_OBJ_DIR)/kmem.o\
+	$(LIBK_OBJ_DIR)/kstd.o
 
 BOOT_OBJ = \
 	$(BOOT_OBJ_DIR)/boot.o

--- a/src/testing/libk/kstd_test.c
+++ b/src/testing/libk/kstd_test.c
@@ -9,10 +9,10 @@ static uint16_t backbuffer[COLS * ROWS];
 static uint16_t frontbuffer[COLS * ROWS];
 
 
-deftest(kprintf__formats_hex_ouput) {
+deftest(kprintf__formats_hex_output) {
   const char *expectedstr = "Test 0x1234\0";
   uint16_t *expectedptr = vga_tell();
-  vga_print(expectedstr);
+  vga_printstr(expectedstr);
   uint16_t *actualptr = vga_setcursor(0, 1);
 
   kprintf("Test %x\0", 0x1234);
@@ -20,10 +20,10 @@ deftest(kprintf__formats_hex_ouput) {
   fact(!kmemcmp(expectedptr, actualptr, sizeof(expectedstr) * sizeof(uint16_t)));
 }
 
-deftest(kprintf__formats_uint_ouput) {
+deftest(kprintf__formats_uint_output) {
   const char *expectedstr = "Test 1234\0";
   uint16_t *expectedptr = vga_tell();
-  vga_print(expectedstr);
+  vga_printstr(expectedstr);
   uint16_t *actualptr = vga_setcursor(0, 1);
 
   kprintf("Test %u\0", 1234);
@@ -31,11 +31,43 @@ deftest(kprintf__formats_uint_ouput) {
   fact(!kmemcmp(expectedptr, actualptr, sizeof(expectedstr) * sizeof(uint16_t)));
 }
 
+deftest(kprintf__formats_int_output) {
+  const char *expectedstr = "Test -1234\0";
+  uint16_t *expectedptr = vga_tell();
+  vga_printstr(expectedstr);
+  uint16_t *actualptr = vga_setcursor(0, 1);
+
+  kprintf("Test %d\0", -1234);
+
+  fact(!kmemcmp(expectedptr, actualptr, sizeof(expectedstr) * sizeof(uint16_t)));
+}
+
+deftest(kprintf__formats_string_output) {
+  const char *expectedstr = "Test abcdef\0";
+  uint16_t *expectedptr = vga_tell();
+  vga_printstr(expectedstr);
+  uint16_t *actualptr = vga_setcursor(0, 1);
+
+  kprintf("Test %s\0", "abcdef");
+
+  fact(!kmemcmp(expectedptr, actualptr, sizeof(expectedstr) * sizeof(uint16_t)));
+}
+
+deftest(kprintf__formats_single_char_output) {
+  const char *expectedstr = "Test c\0";
+  uint16_t *expectedptr = vga_tell();
+  vga_printstr(expectedstr);
+  uint16_t *actualptr = vga_setcursor(0, 1);
+
+  kprintf("Test %c\0", 'c');
+
+  fact(!kmemcmp(expectedptr, actualptr, sizeof(expectedstr) * sizeof(uint16_t)));
+}
+
 deftest(kprintf__puts_percent) {
-  // TODO: DOES NOT WORK!
   const char *expectedstr = "Test %\0";
   uint16_t *expectedptr = vga_tell();
-  vga_print(expectedstr);
+  vga_printstr(expectedstr);
   uint16_t *actualptr = vga_setcursor(0, 1);
 
   kprintf("Test %\0");
@@ -45,8 +77,11 @@ deftest(kprintf__puts_percent) {
 
 
 deffixture(kernel_output) {
-  runtest(kprintf__formats_hex_ouput);
-  runtest(kprintf__formats_uint_ouput);
+  runtest(kprintf__formats_hex_output);
+  runtest(kprintf__formats_uint_output);
+  runtest(kprintf__formats_int_output);
+  runtest(kprintf__formats_string_output);
+  runtest(kprintf__formats_single_char_output);
   runtest(kprintf__puts_percent);
 }
 

--- a/src/testing/libk/vga_test.c
+++ b/src/testing/libk/vga_test.c
@@ -145,7 +145,7 @@ deffixture(display_essentials) {
 
 // Components of the printf function
   
-deftest(vga_print__prints_null_terminated_string) {
+deftest(vga_printstr__prints_null_terminated_string) {
   const char *dummystr = "Hello, world!\0";
   const uint8_t attr = vga_attr(VGA_WHITE, VGA_BLACK);
 
@@ -156,7 +156,7 @@ deftest(vga_print__prints_null_terminated_string) {
   
   vga_reset();
 
-  vga_print(dummystr);
+  vga_printstr(dummystr);
 
   fact(!kmemcmp(backbuffer, valuestr, sizeof(valuestr)));
 }
@@ -202,7 +202,7 @@ deftest(vga_printhex__prints_src_as_hex) {
   const char *valuestr = "0x12345\0";
   
   uint16_t *expectedpos = vga_reset();
-  vga_print(valuestr);
+  vga_printstr(valuestr);
   uint16_t *actualpos = vga_newline();
   vga_printhex(valuelong);
 
@@ -218,7 +218,7 @@ deftest(vga_printuint__prints_src_as_unsigned_decimal) {
   const char *valuestr = "1234\0";
 
   uint16_t *expectedpos = vga_reset();
-  vga_print(valuestr);
+  vga_printstr(valuestr);
   uint16_t *actualpos = vga_newline();
   vga_printuint(valuelong);
 
@@ -234,7 +234,7 @@ deftest(vga_printint__prints_src_as_decimal) {
   const char *valuestr = "-1234\0";
 
   uint16_t *expectedpos = vga_reset();
-  vga_print(valuestr);
+  vga_printstr(valuestr);
   uint16_t *actualpos = vga_newline();
   vga_printint(valuelong);
 
@@ -250,7 +250,7 @@ deftest(vga_printptr__prints_address_of_ptr) {
   const char *valuestr = "0x12345678\0";
 
   uint16_t *expectedpos = vga_reset();
-  vga_print(valuestr);
+  vga_printstr(valuestr);
   uint16_t *actualpos = vga_newline();
   vga_printptr(valueptr);
 
@@ -262,7 +262,7 @@ deftest(vga_printptr__prints_address_of_ptr) {
 
 
 deffixture(printf_components) {
-  runtest(vga_print__prints_null_terminated_string);
+  runtest(vga_printstr__prints_null_terminated_string);
   runtest(vga_newline__performs_linefeed);
   runtest(vga_printhex__prints_src_as_hex);
   runtest(vga_printuint__prints_src_as_unsigned_decimal);


### PR DESCRIPTION
This pull request adds the remaining formats for `kprintf`. In `kmain.c` there is a small example that shows how to use the thing. If you follow the steps there, you should understand how to initialize the graphics driver and change the front- and background colors. 

![image](https://user-images.githubusercontent.com/80746898/191351939-7bdadbbc-d5b4-421c-a3b6-1c16ec032226.png)

Since it is now possible to format text in a useful way, we can use human-readable screen output in future developments. Especially when it comes to things like reading out any hardware configurations, something like this is irreplaceable.