### PR TITLE
A little fix for kprintf

### DIFF
--- a/src/boot/boot.s
+++ b/src/boot/boot.s
@@ -32,18 +32,25 @@
 	// Leave space for the returned header
 	.space 4 * 13
 
+
 	.section .bss
 	.align 16
+
 stack_bottom:
 	.skip 16384
 stack_top:
+
 	push %ebx
 
 	.section .text
+
 	.global _start
 	.type _start, @function
+
 _start:
 	mov $stack_top, %esp
+
+	call kearly
 	call kmain
 
 	cli

--- a/src/kmain.c
+++ b/src/kmain.c
@@ -18,16 +18,22 @@
 static uint16_t _backbuff[VGA_COLS * VGA_ROWS];
 static uint16_t *_frontbuff = (uint16_t*)VGA_FRONTBUFF;
 
-void kmain(void) {
+/*
+ * kearly
+ * Serves as an early startup hook, that gets called right before
+ * kmain. Use this function to do initialization stuff.
+ */
+void kearly(void) {
   vga_configure(_frontbuff, _backbuff, VGA_COLS, VGA_ROWS, TABLEN);
   vga_reset();
-
   vga_setattr(vga_attr(VGA_WHITE, VGA_BLACK));
+}
 
-  kprintf("Hello, %s!\n", "world");
-  vga_setattr(vga_attr(VGA_LIGHT_MAGENTA, VGA_BROWN));
-  
-  kprintf("What is this for %d (%x) improvement!", 1, 1);
-  
-  vga_refresh();
+
+/*
+ * kmain
+ * The kernel main function.
+ */
+void kmain(void) {
+  kprintf("Up and running.\n");
 }

--- a/src/kmain.c
+++ b/src/kmain.c
@@ -35,5 +35,8 @@ void kearly(void) {
  * The kernel main function.
  */
 void kmain(void) {
-  kprintf("Up and running.\n");
+  kprintf("Up and running.\n\0");
+  kprintf("\tAnother line.\n\0");
+  kprintf("\tA third line.\n\0");
+  kprintf("Number %d", 4);
 }

--- a/src/libk/include/kstd.h
+++ b/src/libk/include/kstd.h
@@ -4,6 +4,13 @@
 #  include <stdarg.h>
 #  include "vga.h"
 
+struct gdt_entry {
+  uint32_t base;
+  uint32_t limit;
+  uint8_t flags;
+  uint8_t accessbyte;
+};
+
 /*
  * kprintf
  * Writes formated output to the current cursor position. You can use
@@ -11,21 +18,20 @@
  *
  * %x    hexadecimal
  * %u    unsigned decimal
+ * %d    decimal
+ * %s    string
+ * %c    single char
  *
- * %     percent sign
+ * %%    percent sign
  */
 extern void kprintf(char *format, ...);
 
 /*
- * encode_gdt
- * Creates an entry at for the global descriptor table at @gdtptr
+ * kencode_gdt
+ * Creates an entry for the global descriptor table at @gdtptr
  * containing the @base address, the @limit, the as well as the given
  * @accessbyte and @flags.
  */
-extern void  encode_gdt(uint8_t *gdtptr,
-			uint32_t base,
-			uint32_t limit,
-			uint8_t flags,
-			uint8_t accessbyte);
+extern void kencode_gdt(uint8_t *dest, struct gdt_entry src);
 
 #endif // KSTD_H

--- a/src/libk/include/kstd.h
+++ b/src/libk/include/kstd.h
@@ -16,4 +16,16 @@
  */
 extern void kprintf(char *format, ...);
 
+/*
+ * encode_gdt
+ * Creates an entry at for the global descriptor table at @gdtptr
+ * containing the @base address, the @limit, the as well as the given
+ * @accessbyte and @flags.
+ */
+extern void  encode_gdt(uint8_t *gdtptr,
+			uint32_t base,
+			uint32_t limit,
+			uint8_t flags,
+			uint8_t accessbyte);
+
 #endif // KSTD_H

--- a/src/libk/include/vga.h
+++ b/src/libk/include/vga.h
@@ -53,7 +53,7 @@ typedef struct {
 /*
  * The distance between tabstopps.
  */
-# define TABLEN 10
+#  define TABLEN 10
 
 
 /*
@@ -165,35 +165,43 @@ extern size_t vga_getrow(void);
  */
 extern size_t vga_getcol(void);
 
-
-#define vga_printhex32(src) vga_printhex(src)
-#define vga_printhex16(src) vga_printhex((0 | ((0xffff) & (src))))
-#define vga_printhex8(src) vga_printhex((0 | ((0xff) & (src))))
 /*
  * vga_printhex
  * Prints @src in hex representation at the current cursor position.
  */
 extern uint16_t *vga_printhex(uint32_t src);
+/*
+ * vga_printhex overloads for specific sizes;
+ */
+#  define vga_printhex32(src) vga_printhex(src)
+#  define vga_printhex16(src) vga_printhex(((0xffff) & (src)))
+#  define vga_printhex8(src) vga_printhex(((0xff) & (src)))
 
-#define vga_printuint32(src) vga_printuint(src)
-#define vga_printuint16(src) vga_printuint((0 | ((0xffff) & (src))))
-#define vga_printuint8(src) vga_printuint((0 | ((0xff) & (src))))
 /*
  * vga_printuint
  * Prints @src in unsigned decimal representation at the current
  * cursor position.
  */
 extern uint16_t *vga_printuint(uint32_t src);
+/*
+ * vga_printuint overloads for specific sizes;
+ */
+#  define vga_printuint32(src) vga_printuint(src)
+#  define vga_printuint16(src) vga_printuint(((0xffff) & (src)))
+#  define vga_printuint8(src) vga_printuint(((0xff) & (src)))
 
-#define vga_printint32(src) vga_printint(src)
-#define vga_printint16(src) vga_printint((0 | ((0xffff) & (src))))
-#define vga_printint8(src) vga_printint((0 | ((0xff) & (src))))
 /*
  * vga_printint
  * Prints @src in decimal representation at the current cursor
  * position.
  */
 extern uint16_t *vga_printint(int32_t src);
+/*
+ * vga_printint overloads for specific sizes;
+ */
+#  define vga_printint32(src) vga_printint(src)
+#  define vga_printint16(src) vga_printint(((0xffff) & (src)))
+#  define vga_printint8(src) vga_printint((0xff) & (src)))
 
 /*
  * vga_printptr

--- a/src/libk/include/vga.h
+++ b/src/libk/include/vga.h
@@ -165,12 +165,19 @@ extern size_t vga_getrow(void);
  */
 extern size_t vga_getcol(void);
 
+
+#define vga_printhex32(src) vga_printhex(src)
+#define vga_printhex16(src) vga_printhex((0 | ((0xffff) & (src))))
+#define vga_printhex8(src) vga_printhex((0 | ((0xff) & (src))))
 /*
  * vga_printhex
  * Prints @src in hex representation at the current cursor position.
  */
 extern uint16_t *vga_printhex(uint32_t src);
 
+#define vga_printuint32(src) vga_printuint(src)
+#define vga_printuint16(src) vga_printuint((0 | ((0xffff) & (src))))
+#define vga_printuint8(src) vga_printuint((0 | ((0xff) & (src))))
 /*
  * vga_printuint
  * Prints @src in unsigned decimal representation at the current
@@ -178,6 +185,9 @@ extern uint16_t *vga_printhex(uint32_t src);
  */
 extern uint16_t *vga_printuint(uint32_t src);
 
+#define vga_printint32(src) vga_printint(src)
+#define vga_printint16(src) vga_printint((0 | ((0xffff) & (src))))
+#define vga_printint8(src) vga_printint((0 | ((0xff) & (src))))
 /*
  * vga_printint
  * Prints @src in decimal representation at the current cursor

--- a/src/libk/kbase.s
+++ b/src/libk/kbase.s
@@ -1,0 +1,17 @@
+
+gdtr:
+	.word 0
+	.long 0
+	
+	.type set_gdt, @function
+
+set_gdt:
+	cli
+	mov %ax, 4(%esp)
+	mov [gdtr], %ax
+	mov %eax, 8(%esp)
+	mov [gdtr + 2], %eax
+	lgdt [gdtr]
+	sti
+	ret
+	

--- a/src/libk/kstd.c
+++ b/src/libk/kstd.c
@@ -11,7 +11,7 @@
  * %s    string
  * %c    single char
  *
- * %     percent sign
+ * %%    percent sign
  */
 void kprintf(char *format, ...) {
   char *formatptr = format;
@@ -66,4 +66,27 @@ void kprintf(char *format, ...) {
   }
   
   va_end(args);
+}
+
+
+/*
+ * encode_gdt
+ * Creates an entry at for the global descriptor table at @gdtptr
+ * containing the @base address, the @limit, the as well as the given
+ * @accessbyte and @flags.
+ */
+void  encode_gdt(uint8_t *gdtptr,
+		 uint32_t base,
+		 uint32_t limit,
+		 uint8_t flags,
+		 uint8_t accessbyte) {
+  
+  *gdtptr++ = limit & 0xff;
+  *gdtptr++ = (limit >> 8) & 0xff;
+  *gdtptr++ = base & 0xff;
+  *gdtptr++ = (base >> 8) & 0xff;
+  *gdtptr++ = (base >> 16) & 0xff;
+  *gdtptr++ = accessbyte;
+  *gdtptr++ = (flags << 4);
+  *gdtptr   = (base >> 24) & 0xff;
 }

--- a/src/libk/kstd.c
+++ b/src/libk/kstd.c
@@ -26,6 +26,7 @@ void kprintf(char *format, ...) {
       uint32_t uint_repl;
       int32_t int_repl;
       char *str_repl;
+      char char_repl;
       
       switch (*formatptr) {
       case 'x':
@@ -49,8 +50,8 @@ void kprintf(char *format, ...) {
 	break;
 
       case 'c':
-	int_repl = va_arg(args, int32_t);
-	vga_putch(int_repl);
+	char_repl = va_arg(args, uint32_t);
+	vga_putch(char_repl);
 	break;
 
       default:

--- a/src/libk/kstd.c
+++ b/src/libk/kstd.c
@@ -64,10 +64,10 @@ void kprintf(char *format, ...) {
     
     formatptr++;
   }
-  
-  va_end(args);
-}
 
+  va_end(args);
+  vga_refresh();
+}
 
 /*
  * kencode_gdt

--- a/src/libk/kstd.c
+++ b/src/libk/kstd.c
@@ -70,23 +70,18 @@ void kprintf(char *format, ...) {
 
 
 /*
- * encode_gdt
- * Creates an entry at for the global descriptor table at @gdtptr
+ * kencode_gdt
+ * Creates an entry for the global descriptor table at @gdtptr
  * containing the @base address, the @limit, the as well as the given
  * @accessbyte and @flags.
  */
-void  encode_gdt(uint8_t *gdtptr,
-		 uint32_t base,
-		 uint32_t limit,
-		 uint8_t flags,
-		 uint8_t accessbyte) {
-  
-  *gdtptr++ = limit & 0xff;
-  *gdtptr++ = (limit >> 8) & 0xff;
-  *gdtptr++ = base & 0xff;
-  *gdtptr++ = (base >> 8) & 0xff;
-  *gdtptr++ = (base >> 16) & 0xff;
-  *gdtptr++ = accessbyte;
-  *gdtptr++ = (flags << 4);
-  *gdtptr   = (base >> 24) & 0xff;
+void kencode_gdt(uint8_t *dest, struct gdt_entry src) {
+  *dest++ = src.limit & 0xff;
+  *dest++ = (src.limit >> 8) & 0xff;
+  *dest++ = src.base & 0xff;
+  *dest++ = (src.base >> 8) & 0xff;
+  *dest++ = (src.base >> 16) & 0xff;
+  *dest++ = src.accessbyte;
+  *dest++ = (src.flags << 4);
+  *dest   = (src.base >> 24) & 0xff;
 }

--- a/src/libk/vga.c
+++ b/src/libk/vga.c
@@ -154,11 +154,10 @@ uint16_t *vga_printstr(const char *str) {
  */
 uint16_t *vga_newline(void) {
   _cursorx = 0;
+  _cursory++;
 
-  if (_cursory == _config.sizex -1)
+  if (_cursory == _config.sizey - 1)
     vga_rotup(1);
-  else
-    _cursory++;
 
   return vga_tell();
 }

--- a/src/libk/vga.c
+++ b/src/libk/vga.c
@@ -75,12 +75,13 @@ uint16_t *vga_putch(const char ch) {
 
   default:
     *cursor = vga_ch(ch, _defaultattr);
-
-    if (++_cursorx >= _config.sizex) {
-      ++_cursory;
+    _cursorx++;
+    
+    if (_cursorx > _config.sizex - 1) {
+      _cursory++;
       _cursorx = 0;
 
-      if (_cursory >= _config.sizey)
+      if (_cursory > _config.sizey - 1)
 	vga_rotup(1);
     }
 
@@ -110,7 +111,6 @@ uint16_t *vga_setcursor(size_t col, size_t row) {
 uint16_t *vga_refresh(void) {
   kmemcpy(_config.frontbuff, _config.backbuff,
 	  sizeof(uint16_t) * _config.sizex * _config.sizey);
-  vga_setcursor(0, 0);
 
   return vga_tell();
 }
@@ -156,7 +156,7 @@ uint16_t *vga_newline(void) {
   _cursorx = 0;
   _cursory++;
 
-  if (_cursory == _config.sizey - 1)
+  if (_cursory > _config.sizey - 1)
     vga_rotup(1);
 
   return vga_tell();

--- a/src/makefile
+++ b/src/makefile
@@ -38,7 +38,8 @@ LIBC_OBJ = \
 LIBK_OBJ = \
 	$(LIBK_OBJ_DIR)/vga.o\
 	$(LIBK_OBJ_DIR)/kmem.o\
-	$(LIBK_OBJ_DIR)/kstd.o
+	$(LIBK_OBJ_DIR)/kstd.o\
+	$(LIBK_OBJ_DIR)/kbase.o
 
 BOOT_OBJ = \
 	$(BOOT_OBJ_DIR)/boot.o
@@ -81,7 +82,7 @@ $(LIBC_OBJ_DIR)/%.o: libc/%.c | $(LIBC_OBJ_DIR)
 	$(CC) -c $< -o $@ $(CFLAGS)
 
 $(LIBC_OBJ_DIR):
-	mkdir -p $(LIBC_OBJ_DIR)
+	mkdir -p "$(LIBC_OBJ_DIR)"
 
 
 # Rules for libk
@@ -91,6 +92,9 @@ libk: libc $(LIBK_OBJ)
 
 $(LIBK_OBJ_DIR)/%.o: libk/%.c | $(LIBK_OBJ_DIR)
 	$(CC) -c $< -o $@ $(CFLAGS)
+
+$(LIBK_OBJ_DIR)/%.o: libk/%.s  | $(LIBK_OBJ_DIR)
+	$(AS) -c $< -o $@ $(ASFLAGS)
 
 $(LIBK_OBJ_DIR):
 	mkdir -p $(LIBK_OBJ_DIR)


### PR DESCRIPTION
This PR fixes the control symbols `\n` and `\t` not properly getting print. The reason was, that the `vga_refresh` method reseted the cursor on each call, what made the text always override the first line again and again.